### PR TITLE
Added async loading of footer css

### DIFF
--- a/includes/ucf-footer-common.php
+++ b/includes/ucf-footer-common.php
@@ -16,6 +16,13 @@ if ( !class_exists( 'UCF_Footer_Common' ) ) {
 			}
 		}
 
+		public static function async_load_styles( $html, $handle, $href, $media ) {
+			if ( $handle === 'ucf_footer_css' ) {
+				$html = str_replace( 'media=\'' . $media . '\'', 'media=\'print\' onload=\'this.media="' . $media . '"\'', $html );
+			}
+			return $html;
+		}
+
 		public static function display_social_links() {
 			$menu = UCF_Footer_Feed::get_remote_menu( 'social_menu_url' );
 			if ( !$menu ) { return; }
@@ -76,6 +83,7 @@ if ( !class_exists( 'UCF_Footer_Common' ) ) {
 	}
 
 	add_action( 'wp_enqueue_scripts', array( 'UCF_Footer_Common', 'enqueue_styles' ), 99 );
+	add_action( 'style_loader_tag', array( 'UCF_Footer_Common', 'async_load_styles' ), 99, 4 );
 	add_action( 'wp_footer', array( 'UCF_Footer_Common', 'display_footer' ) );
 
 }


### PR DESCRIPTION
<!---
Thank you for contributing to UCF-Footer-Plugin.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/UCF-Footer-Plugin/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
See title.  Follows the strategy provided here: https://www.filamentgroup.com/lab/load-css-simpler/

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allows this plugin's CSS to not block rendering of pages it's included on.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Tested in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
